### PR TITLE
adding py file for inclusion-exclusion theorem

### DIFF
--- a/SEC-scraper/Inclusion-Exclusion.py
+++ b/SEC-scraper/Inclusion-Exclusion.py
@@ -1,0 +1,25 @@
+import matplotlib
+import matplotlib_venn as vplt
+from matplotlib import pyplot as plt
+
+def generate_dict(count):
+    hash = {}
+    
+    iterations = pow(2, count) - 1
+    for i in range(1, iterations+1):
+        hash[format(i, '0'+str(count)+'b')] = 1
+    print(hash)
+    return(hash)
+
+
+generate_dict(1)
+generate_dict(2)
+generate_dict(3)
+generate_dict(4)
+
+v = vplt.venn2(subsets=generate_dict(2), set_labels = ('A', 'B', 'C'))
+plt.show()
+
+v = vplt.venn3(subsets=generate_dict(3), set_labels = ('A', 'B', 'C'))
+plt.show()
+    


### PR DESCRIPTION
Imported matplotlib venn diagram and played with subsets.

Wrote functions to automatically generate permutations of binary numbers relating to the number of circles in the venn diagram.

However, notice that the package was only limited to 3 circles in the venn plotting.

And that the packages that actually allow more than 3 circles show how absolutely insane these subsections can grow. (ie that it isn't really that useful at the end of the day to plot this theorem with anything bigger than 4 circles.)

anyways, fun few hours to reinforce the knowledge of this 3rd and final "axiom" of combinatorics